### PR TITLE
(Fixes #29) Fixes language calling ability

### DIFF
--- a/examples/fdps_example.py
+++ b/examples/fdps_example.py
@@ -42,5 +42,5 @@ def main():
     while config.time < 1.0:
         invoke(move_part)
         config.time = config.time + config.dt
-        println("", "config.time","\\\" \\\"", "config.dt")
+        println("", "config.time","\" \"", "config.dt")
     cleanup()

--- a/src/HartreeParticleDSL/backends/C_AOS/C_AOS.py
+++ b/src/HartreeParticleDSL/backends/C_AOS/C_AOS.py
@@ -366,8 +366,6 @@ class C_AOS(Backend):
             string = re.sub(", current_indent=[0-9]*, indent=[0-9]*", "", string)
             string = re.sub(" current_indent=[0-9]*, indent=[0-9]*", "", string)
             string = string + ";\n"
-        except TypeError as e:
-            pass
         return string
 
     def set_cutoff(self, cutoff, var_type=CONSTANT, current_indent=0, **kwargs):

--- a/src/HartreeParticleDSL/backends/C_AOS/C_AOS.py
+++ b/src/HartreeParticleDSL/backends/C_AOS/C_AOS.py
@@ -24,8 +24,8 @@ class C_AOS(Backend):
                  c_bool : "_Bool"}
 
     #Variables used to manage where the cutoff radius is stored
-    CONSTANT = 0
-    PARTICLE = 1
+    CONSTANT = "C_AOS.CONSTANT"
+    PARTICLE = "C_AOS.PARTICLE"
 
     def __init__(self):
         self._pairwise_visitor = c_visitors.c_pairwise_visitor(self)
@@ -326,6 +326,7 @@ class C_AOS(Backend):
             raise UnsupportedTypeError("C_AOS does not support type \"{0}\""
                                         " in created variables.".format(c_type))
         ##Check name is allowed in C
+        name = name.replace('"', '')
         a = re.match("[a-zA-Z_][a-zA-Z_0-9]*", name)
         if a is None or a.group(0) != name:
             raise InvalidNameError("C_AOS does not support \"{0}\" as a name"
@@ -336,18 +337,27 @@ class C_AOS(Backend):
         rval = " " * current_indent + C_AOS._type_map.get(c_type) + " " + name + end
         return rval
 
-    def call_language_function(self,func_call, *args):
+    def call_language_function(self,func_call, *args, **kwargs):
         string = ""
         try:
             # Any arguments that were python module accesses would be
             # converted to c pointer accesses here (so use ->).
             # We need to change this into a python module access for now
             # in a temporary variable
-            fixed_func_call = func_call.replace("->", ".")
-            code = compile("self." + fixed_func_call, '<string>', 'eval')
-            string = eval(code)
-        except (SyntaxError, TypeError, AttributeError) as err:
-            string = func_call
+            fn = getattr(self, func_call)
+            fixed_args = []
+            for arg in args:
+                fixed_args.append(arg.replace("->", "."))
+            string = fn(*fixed_args, **kwargs)
+        except (AttributeError) as err:
+            string = func_call + "( "
+            arguments = []
+            for arg in args:
+                arguments.append(arg)
+            for kwarg in kwargs:
+                arguments.append(f"{kwarg}={kwargs[kwarg]}")
+            arg_string = ", ".join(arguments)
+            string = string + arg_string + " )"
             current_index = re.search("current_indent=[0-9]*", string)
             current_indent = 0
             if current_index is not None:
@@ -356,6 +366,8 @@ class C_AOS(Backend):
             string = re.sub(", current_indent=[0-9]*, indent=[0-9]*", "", string)
             string = re.sub(" current_indent=[0-9]*, indent=[0-9]*", "", string)
             string = string + ";\n"
+        except TypeError as e:
+            pass
         return string
 
     def set_cutoff(self, cutoff, var_type=CONSTANT, current_indent=0, **kwargs):

--- a/src/HartreeParticleDSL/backends/C_AOS/visitors.py
+++ b/src/HartreeParticleDSL/backends/C_AOS/visitors.py
@@ -187,7 +187,6 @@ class c_visitor(baseVisitor):
         arguments = []
         # TODO #2L: Temporary version until visitors return strings instead of printing
         for child in node.args:
-            #arguments.append(self.visit(child))
             vis = self.visit(child)
             if type(vis) is str:
                 arguments.append(vis)
@@ -196,13 +195,8 @@ class c_visitor(baseVisitor):
         for child in node.keywords:
             string = f"{child.arg}={self.visit(child.value)}"
             arguments.append(string)
-#        arguments.append(f"current_indent={self._currentIndent}")
-#        arguments.append(f"indent={self._indent}")
-        #func_string = func_string + ", ".join(arguments)
-        #func_string = func_string + " )"
         rval = ""
         if function_name != "invoke":
-#            rval = self._parent.call_language_function(func_string)
             rval = self._parent.call_language_function(function_name, *arguments, current_indent=self._currentIndent,
                                                        indent=self._indent)
         elif function_name == "invoke":

--- a/src/HartreeParticleDSL/backends/C_AOS/visitors.py
+++ b/src/HartreeParticleDSL/backends/C_AOS/visitors.py
@@ -187,17 +187,24 @@ class c_visitor(baseVisitor):
         arguments = []
         # TODO #2L: Temporary version until visitors return strings instead of printing
         for child in node.args:
-            arguments.append(self.visit(child))
+            #arguments.append(self.visit(child))
+            vis = self.visit(child)
+            if type(vis) is str:
+                arguments.append(vis)
+            else:
+                arguments.append(f"{self.visit(child)}")
         for child in node.keywords:
             string = f"{child.arg}={self.visit(child.value)}"
             arguments.append(string)
-        arguments.append(f"current_indent={self._currentIndent}")
-        arguments.append(f"indent={self._indent}")
-        func_string = func_string + ", ".join(arguments)
-        func_string = func_string + " )"
+#        arguments.append(f"current_indent={self._currentIndent}")
+#        arguments.append(f"indent={self._indent}")
+        #func_string = func_string + ", ".join(arguments)
+        #func_string = func_string + " )"
         rval = ""
         if function_name != "invoke":
-            rval = self._parent.call_language_function(func_string)
+#            rval = self._parent.call_language_function(func_string)
+            rval = self._parent.call_language_function(function_name, *arguments, current_indent=self._currentIndent,
+                                                       indent=self._indent)
         elif function_name == "invoke":
             for child in node.args:
                 rval = gen_invoke(child.id, self._currentIndent, self._indent)

--- a/src/HartreeParticleDSL/backends/C_AOS/visitors.py
+++ b/src/HartreeParticleDSL/backends/C_AOS/visitors.py
@@ -188,10 +188,7 @@ class c_visitor(baseVisitor):
         # TODO #2L: Temporary version until visitors return strings instead of printing
         for child in node.args:
             vis = self.visit(child)
-            if type(vis) is str:
-                arguments.append(vis)
-            else:
-                arguments.append(f"{self.visit(child)}")
+            arguments.append(vis)
         for child in node.keywords:
             string = f"{child.arg}={self.visit(child.value)}"
             arguments.append(string)

--- a/src/HartreeParticleDSL/backends/FDPS_backend/FDPS.py
+++ b/src/HartreeParticleDSL/backends/FDPS_backend/FDPS.py
@@ -347,13 +347,20 @@ class FDPS(Backend):
         rval = " " * current_indent + FDPS._type_map.get(c_type) + " " + name + end
         return rval
 
-    def call_language_function(self,func_call, *args):
+    def call_language_function(self,func_call, *args, **kwargs):
         string = ""
         try:
-            code = compile("self." +func_call, '<string>', 'eval')
-            string = eval(code)
+            fn = getattr(self, func_call)
+            string = fn(*args, **kwargs)
         except (SyntaxError, TypeError, AttributeError) as err:
-            string = func_call
+            string = func_call + "( "
+            arguments = []
+            for arg in args:
+                arguments.append(arg)
+            for kwarg in kwargs:
+                arguments.append(f"{kwarg}={kwargs[kwarg]}")
+            arg_string = ", ".join(arguments)
+            string = string + arg_string + " )"
             current_index = re.search("current_indent=[0-9]*", string)
             current_indent = 0
             if current_index is not None:

--- a/src/HartreeParticleDSL/backends/FDPS_backend/FDPS.py
+++ b/src/HartreeParticleDSL/backends/FDPS_backend/FDPS.py
@@ -86,13 +86,17 @@ class FDPS(Backend):
         :param int current_indent: The current indentation level
         :param *args: A list of strings containing the other values
                       to output with cout. Any strings to add to cout
-                      should be surrounded with \\\" \\\".
+                      should be surrounded with \"\".
         :type args: str
         '''
         current_indent = kwargs.get("current_indent", 0)
-        output = " "*current_indent + f"std::cout << \"{string}\""
+        output = " "*current_indent + f"std::cout << {string}"
         for arg in args:
-            output = output + f" << {arg}"
+#            x = arg.replace('"', '')
+            x = arg[0].replace('"', '') + arg[1:]
+            x = x[0:len(x)-1] + x[-1].replace('"', '')
+            
+            output = output + f" << {x}"
         output = output + " << \"\\n\";\n"
         return output
 
@@ -337,6 +341,7 @@ class FDPS(Backend):
             raise UnsupportedTypeError("FDPS does not support type \"{0}\""
                                         " in created variables.".format(c_type))
         ##Check name is allowed in C++
+        name = name.replace('"', '')
         a = re.match("[a-zA-Z_][a-zA-Z_0-9]*", name)
         if a is None or a.group(0) != name:
             raise InvalidNameError("FDPS does not support \"{0}\" as a name"

--- a/src/HartreeParticleDSL/backends/FDPS_backend/FDPS.py
+++ b/src/HartreeParticleDSL/backends/FDPS_backend/FDPS.py
@@ -92,7 +92,6 @@ class FDPS(Backend):
         current_indent = kwargs.get("current_indent", 0)
         output = " "*current_indent + f"std::cout << {string}"
         for arg in args:
-#            x = arg.replace('"', '')
             x = arg[0].replace('"', '') + arg[1:]
             x = x[0:len(x)-1] + x[-1].replace('"', '')
             

--- a/src/HartreeParticleDSL/c_types.py
+++ b/src/HartreeParticleDSL/c_types.py
@@ -1,10 +1,10 @@
 # Defines the c_types available in HartreeParticleDSL that should be supported
 # by the backends.
 
-c_int = "int"
-c_double = "double"
-c_float = "float"
-c_int64_t = "int64_t"
-c_int32_t = "int32_t"
-c_int8_t = "int8_t"
-c_bool = "bool"
+c_int = "c_int"
+c_double = "c_double"
+c_float = "c_float"
+c_int64_t = "c_int64_t"
+c_int32_t = "c_int32_t"
+c_int8_t = "c_int8_t"
+c_bool = "c_bool"

--- a/src/HartreeParticleDSL/test/backends/C_AOS/test_C_AOS.py
+++ b/src/HartreeParticleDSL/test/backends/C_AOS/test_C_AOS.py
@@ -254,15 +254,14 @@ def test_initialise():
 def test_call_language_function():
     '''Test the test_call_language function of C_AOS'''
     backend = C_AOS()
-    func1 = "a_c_call(*part, 20)"
-    rval1 = backend.call_language_function(func1)
-    assert rval1 == (func1 + ";\n")
-    func2 = "cleanup(current_indent=2, indent=1)"
-    rval2 = backend.call_language_function(func2)
+    rval1 = backend.call_language_function("a_c_call", "*part", "20")
+    assert rval1 == ("a_c_call( *part, 20 )" + ";\n")
+#    func2 = "cleanup(current_indent=2, indent=1)"
+    rval2 = backend.call_language_function("cleanup", current_indent=2, indent=1)
     assert rval2 == "  free(config);\n  free(parts);\n"
-    func3 = "a_c_call(*part, 20, current_indent=4, indent=1)"
-    rval3 = backend.call_language_function(func3)
-    assert rval3 == "    a_c_call(*part, 20);\n"
+    #func3 = "a_c_call(*part, 20, current_indent=4, indent=1)"
+    rval3 = backend.call_language_function("a_c_call", "*part", "20", current_indent=4, indent=1)
+    assert rval3 == "    a_c_call( *part, 20 );\n"
 
 
 def test_get_particle_access():

--- a/src/HartreeParticleDSL/test/backends/C_AOS/test_C_AOS.py
+++ b/src/HartreeParticleDSL/test/backends/C_AOS/test_C_AOS.py
@@ -256,10 +256,8 @@ def test_call_language_function():
     backend = C_AOS()
     rval1 = backend.call_language_function("a_c_call", "*part", "20")
     assert rval1 == ("a_c_call( *part, 20 )" + ";\n")
-#    func2 = "cleanup(current_indent=2, indent=1)"
     rval2 = backend.call_language_function("cleanup", current_indent=2, indent=1)
     assert rval2 == "  free(config);\n  free(parts);\n"
-    #func3 = "a_c_call(*part, 20, current_indent=4, indent=1)"
     rval3 = backend.call_language_function("a_c_call", "*part", "20", current_indent=4, indent=1)
     assert rval3 == "    a_c_call( *part, 20 );\n"
 

--- a/src/HartreeParticleDSL/test/backends/C_AOS/test_C_AOS.py
+++ b/src/HartreeParticleDSL/test/backends/C_AOS/test_C_AOS.py
@@ -260,6 +260,8 @@ def test_call_language_function():
     assert rval2 == "  free(config);\n  free(parts);\n"
     rval3 = backend.call_language_function("a_c_call", "*part", "20", current_indent=4, indent=1)
     assert rval3 == "    a_c_call( *part, 20 );\n"
+    rval4 = backend.call_language_function("set_cutoff", "0.5", "C_AOS->CONSTANT")
+    assert rval4 == "config.neighbour_config.cutoff = 0.5;\n"
 
 
 def test_get_particle_access():

--- a/src/HartreeParticleDSL/test/backends/FDPS_backend/test_FDPS.py
+++ b/src/HartreeParticleDSL/test/backends/FDPS_backend/test_FDPS.py
@@ -32,7 +32,7 @@ def test_set_io_modules():
 def test_println():
     ''' Tests the println module of the FDPS backend'''
     backend = FDPS()
-    statement = backend.println("", "total", "\"string123\"", current_indent=0)
+    statement = backend.println("\"\"", "total", "\"\"string123\"\"", current_indent=0)
     assert statement == "std::cout << \"\" << total << \"string123\" << \"\\n\";\n"
 
 def test_addinclude():

--- a/src/HartreeParticleDSL/test/backends/FDPS_backend/test_FDPS.py
+++ b/src/HartreeParticleDSL/test/backends/FDPS_backend/test_FDPS.py
@@ -259,15 +259,14 @@ def test_cleanup():
 def test_call_language_function():
     '''Test the test_call_language function of FDPS'''
     backend = FDPS()
-    func1 = "a_c_call(*part, 20)"
-    rval1 = backend.call_language_function(func1)
+    func1 = "a_c_call( *part, 20 )"
+    rval1 = backend.call_language_function("a_c_call", "*part", "20")
     assert rval1 == (func1 + ";\n")
-    func2 = "cleanup(current_indent=2, indent=1)"
-    rval2 = backend.call_language_function(func2)
+    rval2 = backend.call_language_function("cleanup", current_indent=2, indent=1)
     assert rval2 == "  PS::Finalize();\n"
     func3 = "a_c_call(*part, 20, current_indent=4, indent=1)"
-    rval3 = backend.call_language_function(func3)
-    assert rval3 == "    a_c_call(*part, 20);\n"
+    rval3 = backend.call_language_function("a_c_call", "*part", "20", current_indent=4, indent=1)
+    assert rval3 == "    a_c_call( *part, 20 );\n"
 
 def test_create_variable():
     '''Test the create_variable function of FDPS'''


### PR DESCRIPTION
Switches from a compile/eval model to a `getattr` model. The slight challenge with this is that all arguments are now supplied as strings, so some adaptation needs to be done. This could potentially cause issues in the future, however such issues were already going to happen due to scoping so I'm not too concerned.